### PR TITLE
Triggers copy

### DIFF
--- a/go/base/context.go
+++ b/go/base/context.go
@@ -102,6 +102,7 @@ type MigrationContext struct {
 	GoogleCloudPlatform      bool
 	AzureMySQL               bool
 	AttemptInstantDDL        bool
+	Triggers                 []Trigger
 
 	config            ContextConfig
 	configMutex       *sync.Mutex
@@ -236,6 +237,14 @@ type MigrationContext struct {
 	BinlogSyncerMaxReconnectAttempts int
 
 	Log Logger
+}
+
+type Trigger struct {
+	Definer      string
+	Name         string
+	ActionTiming string
+	Manipulation string
+	Statement    string
 }
 
 type Logger interface {

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -83,9 +83,11 @@ func (this *Inspector) ValidateOriginalTable() (err error) {
 	if err := this.validateTableForeignKeys(this.migrationContext.DiscardForeignKeys); err != nil {
 		return err
 	}
-	if err := this.validateTableTriggers(); err != nil {
-		return err
-	}
+	// TODO
+	this.migrationContext.Log.Info("Ignoring triggers validation - beta testing")
+	//if err := this.validateTableTriggers(); err != nil {
+	//return err
+	//}
 	if err := this.estimateTableRowsViaExplain(); err != nil {
 		return err
 	}

--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -738,8 +738,9 @@ func (this *Inspector) getSharedUniqueKeys(originalUniqueKeys, ghostUniqueKeys [
 	// the ALTER is on the name itself...
 	for _, originalUniqueKey := range originalUniqueKeys {
 		for _, ghostUniqueKey := range ghostUniqueKeys {
-			if originalUniqueKey.Columns.EqualsByNames(&ghostUniqueKey.Columns) {
+			if originalUniqueKey.Columns.IsSubsetOf(&ghostUniqueKey.Columns) {
 				uniqueKeys = append(uniqueKeys, originalUniqueKey)
+				break
 			}
 		}
 	}

--- a/go/logic/inspect_test.go
+++ b/go/logic/inspect_test.go
@@ -17,6 +17,7 @@ func TestInspectGetSharedUniqueKeys(t *testing.T) {
 	origUniqKeys := []*sql.UniqueKey{
 		{Columns: *sql.NewColumnList([]string{"id", "item_id"})},
 		{Columns: *sql.NewColumnList([]string{"id", "org_id"})},
+		{Columns: *sql.NewColumnList([]string{"id"})},
 	}
 	ghostUniqKeys := []*sql.UniqueKey{
 		{Columns: *sql.NewColumnList([]string{"id", "item_id"})},
@@ -25,7 +26,8 @@ func TestInspectGetSharedUniqueKeys(t *testing.T) {
 	}
 	inspector := &Inspector{}
 	sharedUniqKeys := inspector.getSharedUniqueKeys(origUniqKeys, ghostUniqKeys)
-	test.S(t).ExpectEquals(len(sharedUniqKeys), 2)
+	test.S(t).ExpectEquals(len(sharedUniqKeys), 3)
 	test.S(t).ExpectEquals(sharedUniqKeys[0].Columns.String(), "id,item_id")
 	test.S(t).ExpectEquals(sharedUniqKeys[1].Columns.String(), "id,org_id")
+	test.S(t).ExpectEquals(sharedUniqKeys[2].Columns.String(), "id")
 }

--- a/go/logic/migrator.go
+++ b/go/logic/migrator.go
@@ -638,6 +638,12 @@ func (this *Migrator) cutOverTwoStep() (err error) {
 
 // atomicCutOver
 func (this *Migrator) atomicCutOver() (err error) {
+	// TODO - load into memory triggers to be copied
+	err = this.applier.getTriggers(this.migrationContext.OriginalTableName)
+	if err != nil {
+		return this.migrationContext.Log.Errore(err)
+	}
+
 	atomic.StoreInt64(&this.migrationContext.InCutOverCriticalSectionFlag, 1)
 	defer atomic.StoreInt64(&this.migrationContext.InCutOverCriticalSectionFlag, 0)
 
@@ -675,6 +681,7 @@ func (this *Migrator) atomicCutOver() (err error) {
 	renameSessionIdChan := make(chan int64, 2)
 	tablesRenamed := make(chan error, 2)
 	go func() {
+		// TODO triggers a copiar executado depois do rename aqui
 		if err := this.applier.AtomicCutoverRename(renameSessionIdChan, tablesRenamed); err != nil {
 			// Abort! Release the lock
 			atomic.StoreInt64(&tableRenameKnownToHaveFailed, 1)


### PR DESCRIPTION
### Description

This PR adds logic to copy existent triggers from the original table into new one.
While the lock of tables is acquired, and after the tables have been swapped (the original with the new one) the tool will now:
- copy the existent triggers from the original table into memory
- for each trigger
  - delete the trigger from original table
  - recreated the trigger on the new table